### PR TITLE
Add missing arrows: self-loops, and "Index" to "Hyper"

### DIFF
--- a/include/binsparse/c_bindings/binsparse_matrix.h
+++ b/include/binsparse/c_bindings/binsparse_matrix.h
@@ -369,7 +369,7 @@ bc_type_code ;
 //      (..., Index, Hyper, ...) is not valid.
 //
 // (6) (..., Hyper, Sparse, ...) can be defined but is not useful.
-//      The same can be done with (..., Index, Full, ...) by just deleting
+//      The same can be done with (..., Index, Sparse, ...) by just deleting
 //      the pointer for the Hyper axis.  The pointer vector contains a
 //      list of constant stride (see below).
 
@@ -523,12 +523,12 @@ language must be Index or Full.
     (pointer present  <------------------>  no pointer   ---\
     no index. --\                           index present   |
     size is     |                           size is      <--/
-    dim [k]  <--/                      -->  nindex[k]
-           \                          /               \
-            \                        /                 \
-             \                      /                   \
-              \                    /                     \
-               \        "Hyper" <--                       --->  "Full"
+    dim [k]  <--/                    /--->  nindex[k]
+           \                        /                 \
+            \                      /                   \
+             \                    /                     \
+              \                  /                       \
+               \        "Hyper" /                         --->  "Full"
                 \-----> (both pointer --\                       no pointer --\
                         and index.      |                       no index     |
                         size is      <--/                       size is  <---/

--- a/include/binsparse/c_bindings/binsparse_matrix.h
+++ b/include/binsparse/c_bindings/binsparse_matrix.h
@@ -520,18 +520,18 @@ language must be Index or Full.
                                         |   fixed size
 
     "Sparse"                                "Index"
-    (pointer present  <------------------>  no pointer
-    no index.                               index present
-    size is                                 size is
-    dim [k]                          /--->  nindex[k]
-           \                        /                 \
-            \                      /                   \
-             \                    /                     \
-              \                  /                       \
-               \        "Hyper" /                         --->  "Full"
-                \-----> (both pointer                           no pointer
-                        and index.                              no index
-                        size is                                 size is
+    (pointer present  <------------------>  no pointer   ---\
+    no index. --\                           index present   |
+    size is     |                           size is      <--/
+    dim [k]  <--/                      -->  nindex[k]
+           \                          /               \
+            \                        /                 \
+             \                      /                   \
+              \                    /                     \
+               \        "Hyper" <--                       --->  "Full"
+                \-----> (both pointer --\                       no pointer --\
+                        and index.      |                       no index     |
+                        size is      <--/                       size is  <---/
                         nindex [k]                              dim [k]
 
                     |                                       |


### PR DESCRIPTION
@DrTimothyAldenDavis, what do you think?

I think your "Index" followed by "Hyper" (NACHO's "sparse" to "doubly-compressed", or S-DC) makes sense. That is, I disagree with your rule 5.

Rules (1), (3), and (4) could probably be simplified as something like "Full may only follow Index or Full".  You could also try replacing rules 1-4 with something like:
- The final non-"Full" level must be "Index"
- The final "Index" level may be followed by 0 or more "Full" levels

Or try to be even more brief to replace rules 1-4:
- The sparse format must end with "Index" level followed by 0 or more "Full" levels

but perhaps you prefer to exclude each path to "Full" explicitly.

Also, I think rule (6) was supposed to say `(..., Index, Sparse, ...)` instead of `(..., Index, Full, ...)`.